### PR TITLE
Fix for missing requirement.

### DIFF
--- a/lib/twitch/chat/connection.rb
+++ b/lib/twitch/chat/connection.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 module Twitch
   module Chat
     class Connection < EventMachine::Connection


### PR DESCRIPTION
Fix made for santa_kerman running Ruby v2.3.0 as part of the 2016 KSPTV KriSPmas event.